### PR TITLE
fix for #6: check for existing local binaries, fix condition branch for xmllint

### DIFF
--- a/pi
+++ b/pi
@@ -215,7 +215,7 @@ function installLibXMLMSYS () {
 
 function downloadLibXML () {
 	setDownloadApp
-	if ! cmdExists xmllint; then
+	if ! cmdExists xmllint && [ ! -x ./xmllint ]; then
 		echo_nline "Trying to install libxml2..."
 		case "$OSTYPE" in
 			solaris*) 
@@ -250,9 +250,9 @@ function xpath() {
 	downloadLibXML
 	# GitBash doesn't provide /usr/local/bin and cannot copy xmllint.exe to any PATH directory without permission denied
 	if cmdExists xmllint; then
-		./xmllint --nonet --html --shell $2 <<< "cat $1" | sed '/^\/ >/d;/^\ /d'
-	else
 		xmllint --nonet --html --shell $2 <<< "cat $1" | sed '/^\/ >/d;/^\ /d'
+	else
+		./xmllint --nonet --html --shell $2 <<< "cat $1" | sed '/^\/ >/d;/^\ /d'
 	fi
 }
 
@@ -392,7 +392,7 @@ function fetchGitHubPkgNames () {
 	# Download JSON file if not present
 	[ -f $ghPharoIndexFile ] || $dApp $ghPharoTopics -O $ghPharoIndexFile
 
-	if ! cmdExists jq; then
+	if ! cmdExists jq && [ ! -x ./jq ]; then
 		# wget http://stedolan.github.io/jq/download/linux32/jq (32-bit system)
 		echo_nline "Trying to download jq..."
 		case "$OSTYPE" in


### PR DESCRIPTION
This is fix for issue #6.

Testing results:
```
$ which jq && ls ./jq
jq not found

$ pi listgh 2>/dev/null | wc -l && ls ./jq
102
./jq*

$ pi listgh | wc -l
101

```